### PR TITLE
Replace monospace typography overuse

### DIFF
--- a/static/css/additional.css
+++ b/static/css/additional.css
@@ -6,7 +6,8 @@
   margin-left: var(--spacing-sm);
   color: var(--drac-orange);
   font-size: 0.9rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
   font-weight: 500;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -216,8 +216,8 @@ pre code {
 }
 
 blockquote {
-  font-family: var(--font-mono);
-  font-style: normal;
+  font-family: var(--font-sans);
+  font-style: italic;
   padding-left: var(--spacing-md);
   margin-left: 0;
   margin-bottom: var(--spacing-md);
@@ -406,7 +406,8 @@ blockquote {
   color: var(--drac-comment);
   font-size: 0.9rem;
   margin-bottom: var(--spacing-md);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
 }
 
 .post-tags {
@@ -580,7 +581,8 @@ blockquote {
 .archive-date {
   color: var(--drac-comment);
   margin-right: var(--spacing-sm);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
Closes #8

## Changes
- Removed monospace from blockquotes (now sans-serif with italic style)
- Removed monospace from post metadata (now sans-serif with tabular-nums)
- Removed monospace from archive dates (now sans-serif with tabular-nums)
- Removed monospace from reading time (now sans-serif with tabular-nums)
- Reserved monospace only for actual code elements (code, pre, terminal UI)

## Impact
- Improved readability of non-code elements
- Reduced AI slop indicators (monospace as lazy "technical" vibes)
- Blockquotes now use italic style for differentiation
- Metadata uses tabular-nums variant for aligned numbers without monospace

## Monospace Usage After Fix
- **Code elements only:** `code`, `pre` tags
- **Terminal UI elements:** `.terminal-title`, `.terminal-body` (appropriate use)
- **Everything else:** Sans-serif font

## Acceptance Criteria
- [x] Blockquotes use sans-serif with italic style
- [x] Post metadata uses sans-serif with tabular-nums
- [x] Archive dates use sans-serif with tabular-nums
- [x] Reading time uses sans-serif with tabular-nums
- [x] Code blocks still use monospace
- [x] Terminal UI elements still use monospace (appropriate)
- [x] Visual review confirms improved readability
- [x] AI slop score improves