### PR TITLE
Fix touch target size violations (WCAG AA)

### DIFF
--- a/static/css/additional.css
+++ b/static/css/additional.css
@@ -27,9 +27,12 @@
 
 .pagination .step-links a {
   margin: 0 var(--spacing-xs);
-  padding: var(--spacing-xs) var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
   border-radius: 4px;
   transition: all 0.2s ease;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .pagination .step-links a:hover {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -302,8 +302,11 @@ blockquote {
   color: var(--drac-comment);
   text-decoration: none;
   transition: all 0.2s ease;
-  padding: var(--spacing-xs) var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
   border-radius: 4px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .site-navigation a:hover {
@@ -419,10 +422,11 @@ blockquote {
 }
 
 .tag {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   background: rgba(139, 233, 253, 0.15);
   color: var(--drac-cyan);
-  padding: var(--spacing-xs) var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
   border-radius: 4px;
   margin-right: var(--spacing-xs);
   margin-bottom: var(--spacing-xs);
@@ -430,6 +434,7 @@ blockquote {
   border: 1px solid rgba(139, 233, 253, 0.3);
   transition: all 0.2s ease;
   font-weight: 500;
+  min-height: 44px;
 }
 
 .tag:hover {


### PR DESCRIPTION
Closes #6

## Changes
- Increased padding on navigation links to meet 44px minimum touch target size
- Increased padding on tags to meet 44px minimum touch target size
- Increased padding on pagination links to meet 44px minimum touch target size
- Added min-height: 44px and flexbox alignment to all interactive elements

## Technical Details
**Navigation Links** (style.css:301-309)
- Changed padding from `var(--spacing-xs) var(--spacing-sm)` to `var(--spacing-sm) var(--spacing-md)`
- Added `min-height: 44px`, `display: inline-flex`, `align-items: center`

**Tags** (style.css:421-435)
- Changed padding from `var(--spacing-xs) var(--spacing-sm)` to `var(--spacing-sm) var(--spacing-md)`
- Changed display from `inline-block` to `inline-flex` with `align-items: center`
- Added `min-height: 44px`

**Pagination Links** (additional.css:28-35)
- Changed padding from `var(--spacing-xs) var(--spacing-sm)` to `var(--spacing-sm) var(--spacing-md)`
- Added `min-height: 44px`, `display: inline-flex`, `align-items: center`

## Testing
Manual testing approach (Chrome DevTools mobile emulation):
1. Inspect navigation links - verify >= 44px height
2. Inspect tag elements - verify >= 44px height
3. Inspect pagination links - verify >= 44px height
4. Test touch interaction on mobile viewport (375px width)

## WCAG 2.1 AA Compliance
- **Criterion**: 2.5.5 Target Size (Level AA)
- **Requirement**: Touch targets must be at least 44x44 CSS pixels
- **Result**: All interactive elements now meet or exceed minimum size

## Acceptance Criteria
- [x] Navigation links: 44px+ height
- [x] Tags: 44px+ height
- [x] Pagination: 44px+ height
- [x] All elements use flexbox for proper vertical alignment
- [x] Mobile usability improved

## Impact
- Improved accessibility for users with motor impairments
- Better mobile touch experience across all devices
- Meets WCAG 2.1 AA standards (HIGH priority per Livefront engineering standards)