### PR TITLE
#7 Add reduced motion support (WCAG AA best practice)

### DIFF
--- a/static/css/additional.css
+++ b/static/css/additional.css
@@ -364,3 +364,29 @@
   background-color: rgba(255, 255, 255, 0.2);
   border-radius: 4px;
 }
+
+/* =============================================================
+   REDUCED MOTION SUPPORT (WCAG 2.1 AAA - 2.3.3)
+   Disable animations for users with vestibular disorders
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  /* Global animation and transition reduction */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  /* Disable tag hover slideIn animation */
+  .tags a:hover {
+    animation: none !important;
+  }
+
+  /* Disable cursor blink animation */
+  .cursor {
+    animation: none !important;
+  }
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1124,3 +1124,39 @@ figure.markdown-image figcaption {
         padding: 16px;
     }
 }
+
+/* =============================================================
+   REDUCED MOTION SUPPORT (WCAG 2.1 AAA - 2.3.3)
+   Disable animations for users with vestibular disorders
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  /* Global animation and transition reduction */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  /* Explicitly disable signature CRT effects */
+  .crt-overlay {
+    animation: none !important;
+  }
+
+  /* Disable TIL badge pulse */
+  .til-badge {
+    animation: none !important;
+  }
+
+  /* Disable site title flicker and hue-shift */
+  .site-title a {
+    animation: none !important;
+  }
+
+  /* Disable anthropic greeting fade-in */
+  .anthropic-greeting {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Add @media (prefers-reduced-motion: reduce) support across CSS
- Disable all animations via universal selector and specific overrides
- Reduce transitions to 0.01ms for vestibular disorder accessibility
- Achieve WCAG 2.1 AAA compliance (Success Criterion 2.3.3)

## Changes

### style.css
- Global animation/transition reduction via universal selector
- Explicitly disable: CRT overlay effects, TIL badge pulse, site title flicker/hue-shift, anthropic greeting fade-in

### additional.css
- Global animation/transition reduction via universal selector
- Explicitly disable: tag hover slideIn, cursor blink

## Test plan

- [ ] Enable "Reduce motion" in OS accessibility settings
- [ ] Verify site title no longer flickers/shifts hue
- [ ] Verify CRT overlay effects are disabled
- [ ] Verify TIL badge pulse is disabled
- [ ] Verify tag hover animations are disabled
- [ ] Verify cursor blink is disabled
- [ ] Verify all transitions are imperceptible