### PR TITLE
ci: use OIDC for Azure login (no client secret)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # OIDC token for passwordless Azure login (build-and-deploy)
 
 jobs:
   # Job 1: Validation and Testing (runs on all pushes/PRs)
@@ -131,9 +132,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Build and Push Docker Image
         uses: azure/docker-login@v1


### PR DESCRIPTION
Eliminates the Azure client-secret expiry that broke the deploy today (`AADSTS7000222`).

Switches `azure/login` from a stored client secret (`AZURE_CREDENTIALS`) to **OIDC federated authentication**: the workflow requests a short-lived GitHub OIDC token (`id-token: write`) and exchanges it via a federated credential on the app registration that trusts `repo:jamesfishwick/minimalwave-blog:ref:refs/heads/main`. No secret to expire.

- Azure federated credential `github-actions-main` created on app `29ded2fb`.
- `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets set.
- `AZURE_CREDENTIALS` is now unused (can be deleted).

Validated by the deploy this merge triggers.
