### PR TITLE
feat(skill): improve edit-blog-content triggering

### DIFF
--- a/.claude/commands/edit-blog-content.md
+++ b/.claude/commands/edit-blog-content.md
@@ -1,0 +1,17 @@
+---
+description: Edit an existing post's prose (de-slop / zinsser / tighten) via the safe dump -> dry-run -> load workflow
+argument-hint: <what to do, e.g. "de-slop my latest TIL and save it">
+---
+
+Use the **edit-blog-content** skill (`.claude/skills/edit-blog-content/SKILL.md`) to handle this request:
+
+$ARGUMENTS
+
+Follow the skill's workflow exactly — no shortcuts:
+
+1. `dump_content` to export the target entry's markdown field(s) to files.
+2. Run the requested prose skill (de-slopper, zinsser, analyze-prose, ...) on the dumped file, editing only the body below the front-matter.
+3. `load_content --dry-run` as the accept gate: show the diff and confirm before writing.
+4. `load_content` to write the accepted change back through the Django ORM.
+
+Never use raw SQL or the admin form to change content. Work local-first; promote to production only if explicitly asked.

--- a/.claude/skills/edit-blog-content/SKILL.md
+++ b/.claude/skills/edit-blog-content/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: edit-blog-content
-description: Run prose/markdown skills (de-slopper, zinsser, analyze-prose, etc.) against this blog's content and write accepted edits back to the database. Use when the user wants to clean up, rewrite, or improve the markdown body/summary of an Entry, Blogmark, TIL, or Project — e.g. "run the de-slopper on my latest post", "zinsser this entry", "tighten the prose on <slug> and save it". Content lives in Postgres, not files, so this skill exports it to files, edits there, shows a diff for acceptance, then writes back through the Django ORM.
+description: >-
+  Improve the writing in existing posts on James's Postgres-backed Django blog and save the result. Reach for this whenever a user points at content they've already published — an Entry, Blogmark, TIL, or Project, or one of its fields (body, summary, commentary, intro) — and asks to tighten, rewrite, clean up, de-slop, zinsser, or fix "AI-sounding" prose, then wants it persisted back (to the database, postgres, or the db, optionally after syncing prod down or showing a diff first). Any request that combines "make this post read better" with "and save/update/load it" belongs here, whether phrased about the latest post, a named slug, or several recent ones. The skill exports each row to a file, runs the prose skill, shows a diff you approve, and writes back through the Django ORM. Not for drafting new posts, changing dates or other metadata, repairing markdown syntax, or de-slopping repo files like READMEs.
 ---
 
 # Edit blog content

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ ENV/
 # IDE & AI Tools
 .claude/*
 !.claude/skills/
+!.claude/commands/
 .vscode/
 .idea/
 *.swp


### PR DESCRIPTION
Improves how the `edit-blog-content` skill triggers, from the skill-creator description-optimization loop.

- **Optimized description**: the loop's best variant (held-out test 5/8 vs 4/8, zero false positives across all near-misses). Clearer trigger phrasings + an explicit "not for new posts / metadata / markdown syntax / README de-slop" exclusion.
- **`/edit-blog-content` slash command** for guaranteed invocation. The loop showed these tasks are self-serviceable (Claude de-slops + saves inline without consulting a skill), so auto-triggering caps ~50-62% regardless of wording — the command gives a deterministic entry point.
- Track `.claude/commands/` in git.
