### PR TITLE
fix: hide draft blog posts at their public URL

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -120,9 +120,20 @@ def posts(request):
     )
 
 
+def _publicly_visible(qs):
+    """Restrict a BaseEntry queryset to what the public may see: published and
+    not future-scheduled. The canonical detail views use this so a draft 404s at
+    its real URL instead of leaking. Logged-in authors preview drafts through the
+    separate @login_required *_preview views.
+    """
+    return qs.filter(status="published").filter(
+        models.Q(publish_date__isnull=True) | models.Q(publish_date__lte=timezone.now())
+    )
+
+
 def entry(request, year, month, day, slug):
     entry = get_object_or_404(
-        Entry,
+        _publicly_visible(Entry.objects),
         created__year=year,
         created__month=get_month_number(month),
         created__day=day,
@@ -159,7 +170,7 @@ def entry_preview(request, slug):
 
 def blogmark(request, year, month, day, slug):
     blogmark = get_object_or_404(
-        Blogmark,
+        _publicly_visible(Blogmark.objects),
         created__year=year,
         created__month=get_month_number(month),
         created__day=day,

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -89,6 +89,28 @@ class BlogTestCase(TestCase):
         self.assertContains(response, "Test Blog Post")
         self.assertContains(response, "This is the full content of the test blog post.")
 
+    def test_draft_entry_404s_at_canonical_url(self):
+        """A draft entry must 404 at its public URL rather than leak. Reviewing
+        drafts happens through the login-gated entry_preview view."""
+        draft = Entry.objects.create(
+            title="Secret Draft",
+            slug="secret-draft",
+            summary="s",
+            body="hidden body",
+            status="draft",
+        )
+        c = draft.created
+        url = reverse(
+            "blog:entry",
+            kwargs={
+                "year": c.year,
+                "month": c.strftime("%b").lower(),
+                "day": c.day,
+                "slug": draft.slug,
+            },
+        )
+        self.assertEqual(self.client.get(url).status_code, 404)
+
     def test_blogmark(self):
         """Test the blogmark detail page loads correctly"""
         created = self.blogmark.created


### PR DESCRIPTION
The blog `entry` and `blogmark` detail views fetched a post by slug with
no status filter, so a draft was served at its canonical URL. Drafts were
only left out of the index, feed, and sitemap, not actually hidden. The
`projects` app already 404s drafts at their URL; this brings blog posts in
line.

Both canonical detail views now route through a `_publicly_visible()`
helper that requires `status="published"` and a passed `publish_date`, so
a draft (or a future-scheduled post) 404s. The login-gated `entry_preview`
/ `blogmark_preview` views remain the way to review drafts.

Adds `test_draft_entry_404s_at_canonical_url`; the existing published-entry
and blogmark detail tests still pass (13/13 in `tests/test_blog.py`).
