### PR TITLE
style: add semantic .video-embed container

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -299,6 +299,32 @@ figure.markdown-image figcaption {
   margin-top: 0.25rem;
 }
 
+/* ============================================================
+   VIDEO / RESPONSIVE EMBEDS
+   ============================================================ */
+/* Semantic wrapper for video. Holds a third-party iframe embed (Loom,
+   YouTube) or a self-hosted HTML5 <video>; both get the same 16:9 box and
+   spacing. Mirrors .post-image; aspect-ratio replaces the legacy
+   padding-bottom hack, so the embed keeps normal flow. */
+.video-embed {
+  margin: 1.5rem 0;
+}
+
+.video-embed iframe,
+.video-embed video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border: 0;
+}
+
+.video-embed figcaption {
+  font-size: 0.85em;
+  color: var(--drac-comment);
+  margin-top: 0.25rem;
+}
+
 /* Markdown image placement */
 .align-right {
   float: right;


### PR DESCRIPTION
The Loom embed in the blog post used a per-post inline-styled `<div>`
(the `padding-bottom: 56.25%; height: 0` aspect hack) with no vertical
margin, so it butted against surrounding text and wasn't reusable.

Adds a `.video-embed` figure class that mirrors `.post-image` spacing
(`margin: 1.5rem 0`) and uses the modern `aspect-ratio: 16 / 9` to hold
the box. The rule covers both `iframe` (Loom/YouTube) and a self-hosted
HTML5 `<video>`, so the same semantic container works either way.

Content markup switches from the inline `<div>` to
`<figure class="video-embed"><iframe ... title="..."></iframe></figure>`
(handled as a separate DB content change after this deploys, so the
class exists before any content references it). The `title` adds an
accessible name the old embed lacked.
