### PR TITLE
fix: skip link background peeking into viewport

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -195,8 +195,8 @@ body {
    ============================================================ */
 .skip-link {
   position: absolute;
-  top: -40px;
-  left: 0;
+  top: 0;
+  left: -9999px;
   background: var(--drac-purple);
   color: var(--drac-bg);
   padding: 8px 16px;
@@ -206,7 +206,7 @@ body {
 }
 
 .skip-link:focus {
-  top: 0;
+  left: 0;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Problem

On the live site a thin purple horizontal line appears at the very top of the viewport. It's the accessibility skip link ("Skip to main content"): it was hidden with `top: -40px`, but the element's rendered height (text line-height + `padding: 8px 16px`) is greater than 40px, so the bottom sliver of its purple background peeks into view.

## Fix

Hide the link off-screen horizontally with `left: -9999px` (height-independent, so nothing can leak) and reveal it with `left: 0` on `:focus`. The link stays in the DOM and tab order, so the keyboard/screen-reader behavior is unchanged.

## Notes

- Edited the source `static/css/custom.css`. Production serves the collected `staticfiles/` copy, so `make static` (collectstatic) runs on deploy to pick this up.
