### PR TITLE
chore: bump local Postgres 14 to 16 to match prod

### DIFF
--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -27,6 +27,9 @@ services:
     command: supervisord -c /etc/supervisor/conf.d/supervisord.conf
 
   db:
+    # Bumped 14 -> 16 to match Azure prod. An existing postgres_prod_data
+    # volume created under 14 will NOT start under 16 (major-version data-dir
+    # mismatch); recreate the volume (dump/restore or remove it) on upgrade.
     image: postgres:16
     container_name: minimalwave-blog-prod-db
     volumes:

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
     command: supervisord -c /etc/supervisor/conf.d/supervisord.conf
 
   db:
-    image: postgres:14
+    image: postgres:16
     container_name: minimalwave-blog-prod-db
     volumes:
       - postgres_prod_data:/var/lib/postgresql/data/

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - db
 
   db:
-    image: postgres:14
+    image: postgres:16
     container_name: minimalwave-blog-db
     volumes:
       - postgres_data:/var/lib/postgresql/data/

--- a/scripts/sync-db-from-production.sh
+++ b/scripts/sync-db-from-production.sh
@@ -88,9 +88,12 @@ preflight_checks() {
         PG_DUMP_BIN="$PG_DUMP"
     else
         for v in 18 17 16; do
-            candidate="$(brew --prefix "postgresql@$v" 2>/dev/null)/bin/pg_dump"
-            if [ -x "$candidate" ]; then
-                PG_DUMP_BIN="$candidate"
+            # Guard on a non-empty prefix: if brew is absent the substitution
+            # is empty and "$prefix/bin/pg_dump" would collapse to the bogus
+            # "/bin/pg_dump". Skip unless brew returned a real prefix.
+            prefix="$(brew --prefix "postgresql@$v" 2>/dev/null)"
+            if [ -n "$prefix" ] && [ -x "$prefix/bin/pg_dump" ]; then
+                PG_DUMP_BIN="$prefix/bin/pg_dump"
                 break
             fi
         done

--- a/scripts/sync-db-from-production.sh
+++ b/scripts/sync-db-from-production.sh
@@ -79,15 +79,31 @@ preflight_checks() {
     echo -e "${BLUE}Running pre-flight checks...${NC}"
     echo ""
 
-    # Check pg_dump installed
-    if ! command -v pg_dump &> /dev/null; then
+    # Resolve a pg_dump new enough to dump the production server. pg_dump
+    # refuses to dump a server newer than itself, and prod is PostgreSQL 16,
+    # so a stock Homebrew postgresql@14 on PATH fails. Prefer an explicit
+    # $PG_DUMP override, then the newest Homebrew postgresql@NN, then PATH.
+    PG_DUMP_BIN=""
+    if [ -n "${PG_DUMP:-}" ] && command -v "$PG_DUMP" &> /dev/null; then
+        PG_DUMP_BIN="$PG_DUMP"
+    else
+        for v in 18 17 16; do
+            candidate="$(brew --prefix "postgresql@$v" 2>/dev/null)/bin/pg_dump"
+            if [ -x "$candidate" ]; then
+                PG_DUMP_BIN="$candidate"
+                break
+            fi
+        done
+        [ -z "$PG_DUMP_BIN" ] && command -v pg_dump &> /dev/null && PG_DUMP_BIN="pg_dump"
+    fi
+    if [ -z "$PG_DUMP_BIN" ]; then
         echo -e "${RED}❌ pg_dump not found${NC}"
-        echo "Install PostgreSQL client tools:"
-        echo "  macOS: brew install postgresql"
-        echo "  Ubuntu: sudo apt-get install postgresql-client"
+        echo "Install PostgreSQL client tools (v16+ to match production):"
+        echo "  macOS: brew install postgresql@16"
+        echo "  Ubuntu: sudo apt-get install postgresql-client-16"
         exit 1
     fi
-    echo -e "${GREEN}✓ pg_dump installed${NC}"
+    echo -e "${GREEN}✓ pg_dump: $("$PG_DUMP_BIN" --version)${NC}"
 
     # Check Docker running
     if ! docker ps &> /dev/null; then
@@ -197,7 +213,7 @@ export_production_database() {
 
     # Export from Azure PostgreSQL
     echo "Connecting to $PROD_HOST..."
-    PGSSLMODE=require PGPASSWORD="$PROD_PASSWORD" pg_dump \
+    PGSSLMODE=require PGPASSWORD="$PROD_PASSWORD" "$PG_DUMP_BIN" \
         --host="$PROD_HOST" \
         --port="$PROD_PORT" \
         --username="$PROD_USER" \


### PR DESCRIPTION
## Why

Production is Azure PostgreSQL **16**, but the local Docker stack pinned `postgres:14`. This parity gap surfaced while verifying a data migration against a prod copy: the host's `pg_dump` (v14) refuses to dump a v16 server (`server version mismatch`), and more generally local dev wasn't testing on the same major version as prod.

## Change

Bump both compose db services to `postgres:16`:
- `deploy/docker/docker-compose.yml` (local dev)
- `deploy/docker/docker-compose.prod.yml` (self-hosted prod option)

## One-time local step (per machine)

A v14 data directory won't start under v16, so the local volume must be recreated:

```
cd deploy/docker
docker compose -f docker-compose.yml -f docker-compose.dev.yml -p docker down
docker volume rm docker_postgres_data
docker compose -f docker-compose.yml -f docker-compose.dev.yml -p docker up -d
```

Then re-seed with `make sync-db-from-prod` (or import an existing dump).

## Verified locally

- Fresh **postgres:16.11** container starts cleanly.
- A production dump imports without errors (v16 → v16).
- `migrate` reports "No migrations to apply" against real prod data (history consistent).
- Site serves 200 at `/` and `/posts/`.

## Note

`make sync-db-from-prod` relies on the host's default `pg_dump`. On a machine with Homebrew `postgresql@14` ahead of `postgresql@16` on PATH, the sync will still hit the version mismatch — use the v16 binary (`/opt/homebrew/opt/postgresql@16/bin/pg_dump`) or put it first on PATH. A follow-up could pin the script to a v16 `pg_dump`.
