### PR TITLE
chore: prune orphaned django_migrations records

### DIFF
--- a/blog/migrations/0007_prune_legacy_migration_records.py
+++ b/blog/migrations/0007_prune_legacy_migration_records.py
@@ -1,0 +1,56 @@
+"""Delete orphaned rows from the django_migrations table.
+
+Production's migration history carries records for migrations whose files were
+removed long ago: an old pre-squash blog chain (0002-0011, heavy on the
+retired linkedin feature), the deleted linkedin app's initial, and a
+superseded til migration. Django ignores these (they are not in the graph
+built from the on-disk files), but they are confusing cruft. This removes
+exactly those records and nothing else.
+
+Safe by construction:
+- Only the hardcoded (app, name) pairs below are deleted. Every one was
+  confirmed absent from disk yet present in the applied set
+  (MigrationLoader: applied - disk) against a production copy.
+- Idempotent: a second run deletes nothing. On a fresh database (tests, CI)
+  none of these rows exist, so it is a no-op.
+- Never touches a record that has a migration file, so the live graph and
+  every deploy's `migrate` remain unaffected.
+"""
+
+from django.db import migrations
+
+# (app_label, migration_name) records with no corresponding file on disk.
+LEGACY_RECORDS = [
+    ("blog", "0002_blogmark_publish_date_blogmark_status_and_more"),
+    ("blog", "0003_sitesettings"),
+    ("blog", "0004_linkedin_models"),
+    ("blog", "0005_sync_models"),
+    ("blog", "0006_create_default_site"),
+    ("blog", "0007_add_linkedin_fields"),
+    ("blog", "0008_add_linkedin_posted"),
+    ("blog", "0009_rename_linkedin_post_url_field"),
+    ("blog", "0010_sync_linkedin_models"),
+    ("blog", "0011_alter_entry_linkedin_enabled_and_more"),
+    ("linkedin", "0001_initial"),
+    ("til", "0002_add_card_image_and_linkedin_fields"),
+]
+
+
+def prune_legacy_records(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        cursor.executemany(
+            "DELETE FROM django_migrations WHERE app = %s AND name = %s",
+            LEGACY_RECORDS,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("blog", "0006_migrate_til_to_entry"),
+    ]
+
+    operations = [
+        # Reverse is a no-op: deleted history records cannot be meaningfully
+        # recreated, and they were dead weight to begin with.
+        migrations.RunPython(prune_legacy_records, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Why

Production's `django_migrations` table carries **12 orphan records** whose migration files were removed from the repo long ago:
- the old pre-squash blog chain — `0002_blogmark_publish_date…` through `0011_alter_entry_linkedin…` (mostly the retired **linkedin** feature),
- the deleted **linkedin** app's `0001_initial`,
- a superseded `til/0002_add_card_image_and_linkedin_fields`.

Django ignores them (they're not in the graph built from on-disk files), so they're harmless — but they make the history confusing and were flagged during the TIL-migration verification.

## What

A data migration (`blog/0007`) that deletes **exactly those 12 `(app, name)` records and nothing else**. The list was computed against a production copy with Django's own `MigrationLoader` (`applied - on_disk`), so by construction it can't touch any record that still has a migration file.

- **Idempotent** — a second run deletes nothing.
- **No-op on fresh databases** (tests/CI) — none of the rows exist there.
- **Never touches the live graph** — every current migration file stays applied.

## Verified against a prod copy (local Postgres 16)

```
orphan records before: 12
orphan records after:  0        (MigrationLoader: applied - on_disk)
on-disk not applied:   0        (nothing broken)
blog chain now: 0001_initial, 0002_add_image_fields, 0003_rename_image_alt_to_image_caption,
                0004_remove_linkedin, 0005_alter_blogmark_tags_alter_entry_tags,
                0006_migrate_til_to_entry, 0007_prune_legacy_migration_records
migrate --check: exit 0
site: 200
```

Full suite green (105 tests).

## Deploy note

Applies through the normal pipeline (the container runs `migrate` on release) — no manual production database access. Depends on `blog/0006` (merged in #37).
