### PR TITLE
fix: show all entries on the archive page

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -292,16 +292,16 @@ def archive(request):
         .order_by("-created")
     )
 
-    # Paginate entries
-    paginated_entries = paginate_queryset(request, entries)
-
+    # The archive is a complete chronological index (title + link + date,
+    # grouped by year/month in the template), so list every entry rather than
+    # a single page. The template has no pagination controls, so paginating
+    # here would strand everything past the first page.
     return render(
         request,
         "blog/archive.html",
         {
-            "entries": paginated_entries,
+            "entries": entries,
             "blogmarks": blogmarks,
-            "page_obj": paginated_entries,
         },
     )
 

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -131,6 +131,29 @@ class BlogTestCase(TestCase):
         self.assertContains(response, "Test Blog Post")
         self.assertContains(response, "Test Link")
 
+    def test_archive_lists_all_entries_unpaginated(self):
+        """The archive is a full chronological index: an old entry that would
+        fall past the first paginator page must still appear. Guards against
+        re-paginating the archive and stranding older posts (e.g. migrated
+        TILs) on an unreachable page."""
+        from datetime import timedelta
+
+        base = timezone.now()
+        for i in range(15):
+            Entry.objects.create(
+                title=f"Archive Entry {i}",
+                slug=f"archive-entry-{i}",
+                summary="s",
+                body="b",
+                status="published",
+                created=base - timedelta(days=i + 1),
+            )
+        response = self.client.get(reverse("blog:archive"))
+        self.assertEqual(response.status_code, 200)
+        # The oldest would sit on page 2 under a 10-per-page paginator.
+        self.assertContains(response, "Archive Entry 14")
+        self.assertContains(response, "Archive Entry 0")
+
 
 class TemplateValidationTests(TestCase):
     """Test that all templates can be compiled without syntax errors."""


### PR DESCRIPTION
## Why

`/archive/` only ever showed the 10 most-recent entries. The view paginated its entries (`paginate_queryset`, 10/page) but `templates/blog/archive.html` has **no pagination controls**, so page 2+ was unreachable. Every older post was stranded — including the 7 migrated **TIL** entries (dated 2025), which is why they appeared "missing" from the archive even though they converted correctly and are live at their canonical URLs and under `/tag/til/`.

## Fix

The template already renders a complete year → month → day index of **title + link + date**. So the fix is one line of intent: hand it the full queryset instead of a single page. Removed the pagination from the `archive` view.

- No template change (it already does titles/links/dates).
- No pagination UI needed — the whole archive is one chronological list, as requested.

## Verified locally (against a prod-data copy)

- `/archive/` now lists **all 27 published entries** on one page, including every TIL (`reranking`, `aws-dms-…`, `the-linkedin-sharing-paradox-…`, `document-extraction-…`).
- Added a regression test: create 15 dated entries, assert the oldest still appears on `/archive/` (it would fall past a 10-per-page paginator). Full blog suite green.

## Scope note

Only the `archive` view changed. The `year` and `month` views still paginate (they're narrower and less affected); if you want those unpaginated too, easy follow-up.
