### PR TITLE
style: two-column layout for archive rows

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -411,14 +411,24 @@ details.post-summary > p:last-child {
   margin: 0;
 }
 
+/* Two-column rows: fixed date column + title column. A title that overruns
+   wraps within its own column instead of flowing back under the date. */
 .archive-list li {
+  display: flex;
+  gap: 1rem;
   margin-bottom: 0.2rem;
 }
 
 .archive-date {
+  flex: 0 0 1.5rem;
+  text-align: right;
   color: var(--drac-comment);
-  margin-right: 1rem;
   font-variant-numeric: tabular-nums;
+}
+
+.archive-list li a {
+  flex: 1;
+  min-width: 0;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Why

Archive rows put the date and title inline (`<span> <a>`), so a title that overran the line wrapped **back under the date** — ragged and hard to scan.

## Change

Make each `.archive-list li` a flex row:
- fixed, right-aligned **date column** (`flex: 0 0 1.5rem`)
- **title column** takes the rest (`flex: 1; min-width: 0` so it can wrap)

An overrunning title now wraps under itself with a clean hanging indent, aligned to the title column — not the date.

CSS-only, `static/css/custom.css`. Applies to entry and blogmark rows alike.

## Verified

Screenshotted the local archive at a deliberately narrow **480px** against the longest title on the page ("The LinkedIn Sharing Paradox: Why Testing Social Media Integration is Harder Than It Should Be"): all wrapped lines align under the title's first line, day numbers stay right-aligned in their column.
