### PR TITLE
style: collapse extra blank lines in templates

### DIFF
--- a/templates/blog/archive.html
+++ b/templates/blog/archive.html
@@ -19,26 +19,20 @@
   <section class="archive">
   <h1>Archive</h1>
 
-
   {% regroup entries by created.year as entries_by_year %}
 
-
   {% regroup blogmarks by created.year as blogmarks_by_year %}
-
 
   {% for year, year_entries in entries_by_year %}
 
     <h2 class="archive-year">{{ year }}</h2>
 
-
     {% regroup year_entries by created|date:"F" as entries_by_month %}
-
 
     {% for month, month_entries in entries_by_month %}
 
       <h3 class="archive-month">{{ month }}</h3>
       <ul class="archive-list">
-
 
       {% for entry in month_entries %}
 
@@ -47,24 +41,17 @@
         <a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a>
         </li>
 
-
       {% endfor %}
-
 
       {% for by_year in blogmarks_by_year %}
 
-
         {% if by_year.grouper == year %}
-
 
           {% regroup by_year.list by created|date:"F" as blogmarks_by_month %}
 
-
           {% for by_month in blogmarks_by_month %}
 
-
             {% if by_month.grouper == month %}
-
 
               {% for blogmark in by_month.list %}
 
@@ -75,15 +62,11 @@
 
               {% endfor %}
 
-
             {% endif %}
-
 
           {% endfor %}
 
-
         {% endif %}
-
 
       {% endfor %}
 
@@ -91,9 +74,7 @@
 
       </ul>
 
-
     {% endfor %}
-
 
   {% endfor %}
 

--- a/templates/blog/blogmark.html
+++ b/templates/blog/blogmark.html
@@ -72,7 +72,6 @@
 
 {% block twitter_image %}
 
-
   {% if blogmark.get_image_url %}
 
     <meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ blogmark.get_image_url }}" />
@@ -169,7 +168,6 @@
 
 {% block content %}
 
-
   {% if preview %}
 
     <div class="preview-banner">
@@ -201,7 +199,6 @@
 
   <a href="{{ blogmark.url }}" class="blogmark-url" target="_blank" rel="nofollow ugc noopener">{{ blogmark.url }}</a>
 
-
   {% if blogmark.get_image_url %}
 
     <figure class="post-image">
@@ -221,22 +218,18 @@
   {{ blogmark.commentary_rendered }}
   </div>
 
-
   {% if blogmark.via %}
 
     <div class="blogmark-via">
     Via: <a href="{{ blogmark.via }}" target="_blank" rel="nofollow ugc noopener">{{ blogmark.via_title|default:blogmark.via }}</a>
     </div>
 
-
   {% endif %}
-
 
   {% if blogmark.tags.exists %}
 
     <div class="post-tags">
     <h3>Tags:</h3>
-
 
     {% for tag in blogmark.tags.all %}
 
@@ -246,11 +239,9 @@
 
       " class="tag">{{ tag.name }}</a>
 
-
     {% endfor %}
 
     </div>
-
 
   {% endif %}
 

--- a/templates/blog/entry.html
+++ b/templates/blog/entry.html
@@ -77,7 +77,6 @@
 
 {% block twitter_image %}
 
-
   {% if entry.get_image_url %}
 
     <meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ entry.get_image_url }}" />
@@ -210,12 +209,9 @@
         ,
       {% endif %}
 
-
     {% endfor %}
 
-
   {% endif %}
-
 
   {% if reading_time %}
 
@@ -225,7 +221,6 @@
 
   </div>
   </header>
-
 
   {% if entry.get_image_url %}
 
@@ -249,7 +244,6 @@
 
   <div class="post-body">{{ entry.body_rendered }}</div>
 
-
   {% if entry.tags.exists %}
 
     <div class="post-tags">
@@ -262,21 +256,17 @@
 
       " class="tag">{{ tag.name }}</a>
 
-
     {% endfor %}
 
     </div>
 
-
   {% endif %}
-
 
   {% if related_entries %}
 
     <div class="related-posts">
     <h3>Related Posts</h3>
     <div class="related-posts-grid">
-
 
     {% for related in related_entries %}
 
@@ -287,12 +277,10 @@
       <div class="post-meta"><time datetime="{{ related.created|date:'Y-m-d' }}">{{ related.created|date:"F j, Y" }}</time></div>
       </div>
 
-
     {% endfor %}
 
     </div>
     </div>
-
 
   {% endif %}
 

--- a/templates/blog/posts.html
+++ b/templates/blog/posts.html
@@ -11,7 +11,6 @@
   <section class="blog-index" aria-labelledby="latest-posts-heading">
   <h1 id="latest-posts-heading">Latest Posts</h1>
 
-
   {% for entry in entries %}
 
     <article>
@@ -30,12 +29,9 @@
           ,
         {% endif %}
 
-
       {% endfor %}
 
-
     {% endif %}
-
 
     {% if entry.reading_time %}
 
@@ -73,7 +69,6 @@
 
   {% endfor %}
 
-
   {% if has_more %}
 
     <p>
@@ -88,7 +83,6 @@
 
   <section class="blogmarks" aria-labelledby="recent-links-heading">
   <h2 id="recent-links-heading">Recent Links</h2>
-
 
   {% for blogmark in blogmarks %}
 
@@ -105,7 +99,6 @@
       </div>
 
     {% endif %}
-
 
     {% if blogmark.tags.exists %}
 
@@ -139,7 +132,6 @@
 {% endblock %}
 
 {% block aside %}
-
 
   {% if tags %}
 

--- a/templates/blog/search.html
+++ b/templates/blog/search.html
@@ -52,16 +52,13 @@
   <button type="submit">Search</button>
   </form>
 
-
   {% if q %}
 
     <p>Results for "{{ q }}":</p>
 
-
     {% if entries %}
 
       <h2>Blog Posts</h2>
-
 
       {% for entry in entries %}
 
@@ -72,11 +69,9 @@
         {{ entry.summary_rendered }}
         </div>
 
-
         {% if entry.tags.exists %}
 
           <div class="post-tags">
-
 
           {% for tag in entry.tags.all %}
 
@@ -86,27 +81,21 @@
 
             " class="tag">{{ tag.name }}</a>
 
-
           {% endfor %}
 
           </div>
-
 
         {% endif %}
 
         </article>
 
-
       {% endfor %}
 
-
     {% endif %}
-
 
     {% if blogmarks %}
 
       <h2>Links</h2>
-
 
       {% for blogmark in blogmarks %}
 
@@ -118,11 +107,9 @@
         {{ blogmark.commentary_rendered }}
         </div>
 
-
         {% if blogmark.tags.exists %}
 
           <div class="post-tags">
-
 
           {% for tag in blogmark.tags.all %}
 
@@ -132,35 +119,27 @@
 
             " class="tag">{{ tag.name }}</a>
 
-
           {% endfor %}
 
           </div>
-
 
         {% endif %}
 
         </article>
 
-
       {% endfor %}
 
-
     {% endif %}
-
 
     {% if not entries and not blogmarks %}
 
       <p>No results found for "{{ q }}".</p>
 
-
     {% endif %}
-
 
     {% else %}
 
     <p>Enter a search term above to find content.</p>
-
 
   {% endif %}
 

--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -43,11 +43,9 @@
   <section class="tag-page">
   <h1>Tag: {{ tag.name }}</h1>
 
-
   {% if entries %}
 
     <h2>Blog Posts</h2>
-
 
     {% for entry in entries %}
 
@@ -59,17 +57,13 @@
       </div>
       </article>
 
-
     {% endfor %}
 
-
   {% endif %}
-
 
   {% if blogmarks %}
 
     <h2>Links</h2>
-
 
     {% for blogmark in blogmarks %}
 
@@ -82,17 +76,13 @@
       </div>
       </article>
 
-
     {% endfor %}
 
-
   {% endif %}
-
 
   {% if not entries and not blogmarks %}
 
     <p>No content with this tag yet.</p>
-
 
   {% endif %}
 

--- a/templates/projects/_card.html
+++ b/templates/projects/_card.html
@@ -33,7 +33,6 @@
   <a href="{{ project.repo_url }}" rel="noopener">Code</a>
 {% endif %}
 
-
 {% if project.live_url %}
   <a href="{{ project.live_url }}" rel="noopener">Live</a>
 {% endif %}

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -73,7 +73,6 @@
 
 {% block twitter_image %}
 
-
   {% if project.get_image_url %}
 
     <meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ project.get_image_url }}" />
@@ -175,14 +174,12 @@
   <a href="{{ project.repo_url }}" rel="noopener" class="button">View code</a>
 {% endif %}
 
-
 {% if project.live_url %}
   <a href="{{ project.live_url }}" rel="noopener" class="button">Visit live site</a>
 {% endif %}
 
 </div>
 </header>
-
 
 {% if project.get_image_url %}
 
@@ -191,7 +188,6 @@
   </figure>
 
 {% endif %}
-
 
 {% if project.tech_stack_list %}
 
@@ -210,7 +206,6 @@
 <div class="project-content">
 {{ project.body_rendered }}
 </div>
-
 
 {% if project.tags.exists %}
 

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -18,7 +18,6 @@
   <section class="projects-index" aria-labelledby="projects-heading">
   <h1 id="projects-heading">Projects</h1>
 
-
   {% if featured_projects %}
 
     <div class="projects-featured" aria-labelledby="featured-heading">
@@ -27,9 +26,7 @@
 
     {% for project in featured_projects %}
 
-
       {% include "projects/_card.html" with project=project %}
-
 
     {% endfor %}
 
@@ -49,12 +46,9 @@
 
   {% for project in projects %}
 
-
     {% include "projects/_card.html" with project=project %}
 
-
     {% empty %}
-
 
     {% if not featured_projects %}
 
@@ -67,7 +61,6 @@
       </div>
 
     {% endif %}
-
 
   {% endfor %}
 

--- a/templates/projects/tag.html
+++ b/templates/projects/tag.html
@@ -22,9 +22,7 @@
 
   {% for project in projects %}
 
-
     {% include "projects/_card.html" with project=project %}
-
 
     {% empty %}
 


### PR DESCRIPTION
Whitespace-only cleanup: remove redundant blank lines from the blog and
project list/detail templates (archive, blogmark, entry, posts, search,
tag; projects card/detail/index/tag). No markup or logic changes — 94
blank-line deletions across 10 files.

`manage.py check` clean; templates compile; full suite green on push.
